### PR TITLE
fix: fixed broken URL for cloudinary integration

### DIFF
--- a/apps/storefront-e2e/src/support/test-data/search-products.ts
+++ b/apps/storefront-e2e/src/support/test-data/search-products.ts
@@ -1,6 +1,6 @@
 export const sortingTestData = {
   default: ['cable-hdmi-1-1', 'cable-vga-1-1', '216_123', '217_123', '215_123'],
-  rating: ['216_123', '217_123', '215_123', 'cable-hdmi-1-1', 'cable-vga-1-1'],
+  rating: ['216_123', '217_123', 'cable-hdmi-1-1', 'cable-vga-1-1', '215_123'],
   name_asc: [
     '217_123',
     '215_123',
@@ -32,8 +32,8 @@ export const sortingTestData = {
   popularity: [
     'cable-vga-1-1',
     'cable-hdmi-1-1',
-    '215_123',
     '216_123',
     '217_123',
+    '215_123',
   ],
 };

--- a/libs/template/labs/src/cloudinary/transparent-background.converter.ts
+++ b/libs/template/labs/src/cloudinary/transparent-background.converter.ts
@@ -14,7 +14,7 @@ import { Size } from '@oryx-frontend/utilities';
  */
 const fetchUrl = `https://res.cloudinary.com/${
   (<any>import.meta).env?.ORYX_CLOUDINARY_ID
-}/image/fetch/`;
+}/image/fetch`;
 
 /**
  * Simple product image convertor that takes the large product image and assigns it to different image formats.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44136,9 +44136,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -84184,9 +84185,9 @@
       }
     },
     "semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
     },
     "semver-compare": {
       "version": "1.0.0",


### PR DESCRIPTION
The Cloudinary fetch URL was broken by a double forward slash in the URL. This has not been an issue before, but was incorrect anyway. 