### PR TITLE
fix: text for non-bright colors are not accessible 

### DIFF
--- a/libs/platform/experience/src/color/colors/colored/blue.ts
+++ b/libs/platform/experience/src/color/colors/colored/blue.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const blue: Color = {
   light: {
+    0: 'white',
     1: 'hsl(206, 100%, 99.2%)',
     2: 'hsl(210, 100%, 98%)',
     3: 'hsl(209, 100%, 96.5%)',
@@ -16,6 +17,7 @@ export const blue: Color = {
     12: 'hsl(211, 100%, 15%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(212, 35%, 9.2%)',
     2: 'hsl(216, 50%, 11.8%)',
     3: 'hsl(214, 59.4%, 15.3%)',

--- a/libs/platform/experience/src/color/colors/colored/bronze.ts
+++ b/libs/platform/experience/src/color/colors/colored/bronze.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const bronze: Color = {
   light: {
+    0: 'white',
     1: '#fdfcfc',
     2: '#fdf7f5',
     3: '#f6edea',
@@ -16,6 +17,7 @@ export const bronze: Color = {
     12: '#43302b',
   },
   dark: {
+    0: 'white',
     1: '#141110',
     2: '#1c1917',
     3: '#262220',

--- a/libs/platform/experience/src/color/colors/colored/brown.ts
+++ b/libs/platform/experience/src/color/colors/colored/brown.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const brown: Color = {
   light: {
+    0: 'white',
     1: 'hsl(30, 40.0%, 99.1%)',
     2: 'hsl(30, 50.0%, 97.6%)',
     3: 'hsl(30, 52.5%, 94.6%)',
@@ -16,6 +17,7 @@ export const brown: Color = {
     12: 'hsl(20, 30.0%, 19.0%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(22, 15.0%, 8.7%)',
     2: 'hsl(20, 28.3%, 10.4%)',
     3: 'hsl(20, 28.0%, 14.0%)',

--- a/libs/platform/experience/src/color/colors/colored/crimson.ts
+++ b/libs/platform/experience/src/color/colors/colored/crimson.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const crimson: Color = {
   light: {
+    0: 'white',
     1: 'hsl(332, 100%, 99.4%)',
     2: 'hsl(330, 100%, 98.4%)',
     3: 'hsl(331, 85.6%, 96.6%)',
@@ -16,6 +17,7 @@ export const crimson: Color = {
     12: 'hsl(340, 65.0%, 14.5%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(335, 20%, 9.6%)',
     2: 'hsl(335, 32.2%, 11.6%)',
     3: 'hsl(335, 42.5%, 16.5%)',

--- a/libs/platform/experience/src/color/colors/colored/cyan.ts
+++ b/libs/platform/experience/src/color/colors/colored/cyan.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const cyan: Color = {
   light: {
+    0: 'white',
     1: 'hsl(185, 60.0%, 98.7%)',
     2: 'hsl(185, 73.3%, 97.1%)',
     3: 'hsl(186, 70.2%, 94.4%)',
@@ -16,6 +17,7 @@ export const cyan: Color = {
     12: 'hsl(192, 88.0%, 12.5%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(192, 60.0%, 7.2%)',
     2: 'hsl(192, 71.4%, 8.2%)',
     3: 'hsl(192, 75.9%, 10.8%)',

--- a/libs/platform/experience/src/color/colors/colored/gold.ts
+++ b/libs/platform/experience/src/color/colors/colored/gold.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const gold: Color = {
   light: {
+    0: 'white',
     1: '#fdfdfc',
     2: '#faf9f2',
     3: '#f2f0e7',
@@ -16,6 +17,7 @@ export const gold: Color = {
     12: '#3b352b',
   },
   dark: {
+    0: 'white',
     1: '#121211',
     2: '#1b1a17',
     3: '#24231f',

--- a/libs/platform/experience/src/color/colors/colored/grass.ts
+++ b/libs/platform/experience/src/color/colors/colored/grass.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const grass: Color = {
   light: {
+    0: 'white',
     1: 'hsl(116, 50.0%, 98.9%)',
     2: 'hsl(120, 60.0%, 97.1%)',
     3: 'hsl(120, 53.6%, 94.8%)',
@@ -16,6 +17,7 @@ export const grass: Color = {
     12: 'hsl(130, 30.0%, 14.9%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(146, 30.0%, 7.4%)',
     2: 'hsl(136, 33.3%, 8.8%)',
     3: 'hsl(137, 36.0%, 11.4%)',

--- a/libs/platform/experience/src/color/colors/colored/indigo.ts
+++ b/libs/platform/experience/src/color/colors/colored/indigo.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const indigo: Color = {
   light: {
+    0: 'white',
     1: 'hsl(225, 60.0%, 99.4%)',
     2: 'hsl(223, 100%, 98.6%)',
     3: 'hsl(223, 98.4%, 97.1%)',
@@ -16,6 +17,7 @@ export const indigo: Color = {
     12: 'hsl(226, 62.0%, 17.0%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(229, 24.0%, 10.0%)',
     2: 'hsl(230, 36.4%, 12.9%)',
     3: 'hsl(228, 43.3%, 17.5%)',

--- a/libs/platform/experience/src/color/colors/colored/iris.ts
+++ b/libs/platform/experience/src/color/colors/colored/iris.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const iris: Color = {
   light: {
+    0: 'white',
     1: '#fdfdff',
     2: '#f8f8ff',
     3: '#f0f1fe',
@@ -16,6 +17,7 @@ export const iris: Color = {
     12: '#272962',
   },
   dark: {
+    0: 'white',
     1: '#13131e',
     2: '#171625',
     3: '#202248',

--- a/libs/platform/experience/src/color/colors/colored/jade.ts
+++ b/libs/platform/experience/src/color/colors/colored/jade.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const jade: Color = {
   light: {
+    0: 'white',
     1: '#fbfefd',
     2: '#f4fbf7',
     3: '#e6f7ed',
@@ -16,6 +17,7 @@ export const jade: Color = {
     12: '#1d3b31',
   },
   dark: {
+    0: 'white',
     1: '#0d1512',
     2: '#121c18',
     3: '#0f2e22',

--- a/libs/platform/experience/src/color/colors/colored/orange.ts
+++ b/libs/platform/experience/src/color/colors/colored/orange.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const orange: Color = {
   light: {
+    0: 'white',
     1: 'hsl(24, 70.0%, 99.0%)',
     2: 'hsl(24, 83.3%, 97.6%)',
     3: 'hsl(24, 100%, 95.3%)',
@@ -16,6 +17,7 @@ export const orange: Color = {
     12: 'hsl(15, 60.0%, 17.0%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(30, 70.0%, 7.2%)',
     2: 'hsl(28, 100%, 8.4%)',
     3: 'hsl(26, 91.1%, 11.6%)',

--- a/libs/platform/experience/src/color/colors/colored/pink.ts
+++ b/libs/platform/experience/src/color/colors/colored/pink.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const pink: Color = {
   light: {
+    0: 'white',
     1: 'hsl(322, 100%, 99.4%)',
     2: 'hsl(323, 100%, 98.4%)',
     3: 'hsl(323, 86.3%, 96.5%)',
@@ -16,6 +17,7 @@ export const pink: Color = {
     12: 'hsl(320, 70.0%, 13.5%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(318, 25.0%, 9.6%)',
     2: 'hsl(319, 32.2%, 11.6%)',
     3: 'hsl(319, 41.0%, 16.0%)',

--- a/libs/platform/experience/src/color/colors/colored/plum.ts
+++ b/libs/platform/experience/src/color/colors/colored/plum.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const plum: Color = {
   light: {
+    0: 'white',
     1: 'hsl(292, 90.0%, 99.4%)',
     2: 'hsl(300, 100%, 98.6%)',
     3: 'hsl(299, 71.2%, 96.4%)',
@@ -16,6 +17,7 @@ export const plum: Color = {
     12: 'hsl(291, 66.0%, 14.0%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(301, 20.0%, 9.4%)',
     2: 'hsl(300, 29.8%, 11.2%)',
     3: 'hsl(298, 34.4%, 15.3%)',

--- a/libs/platform/experience/src/color/colors/colored/purple.ts
+++ b/libs/platform/experience/src/color/colors/colored/purple.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const purple: Color = {
   light: {
+    0: 'white',
     1: 'hsl(280, 65.0%, 99.4%)',
     2: 'hsl(276, 100%, 99.0%)',
     3: 'hsl(276, 83.1%, 97.0%)',
@@ -16,6 +17,7 @@ export const purple: Color = {
     12: 'hsl(272, 66.0%, 16.0%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(284, 20.0%, 9.6%)',
     2: 'hsl(283, 30.0%, 11.8%)',
     3: 'hsl(281, 37.5%, 16.5%)',

--- a/libs/platform/experience/src/color/colors/colored/ruby.ts
+++ b/libs/platform/experience/src/color/colors/colored/ruby.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const ruby: Color = {
   light: {
+    0: 'white',
     1: '#fffcfd',
     2: '#fff7f8',
     3: '#feeaed',
@@ -16,6 +17,7 @@ export const ruby: Color = {
     12: '#64172b',
   },
   dark: {
+    0: 'white',
     1: '#191113',
     2: '#1e1517',
     3: '#3a141e',

--- a/libs/platform/experience/src/color/colors/colored/tomato.ts
+++ b/libs/platform/experience/src/color/colors/colored/tomato.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const tomato: Color = {
   light: {
+    0: 'white',
     1: 'hsl(10, 100%, 99.4%)',
     2: 'hsl(8, 100%, 98.4%)',
     3: 'hsl(8, 100%, 96.6%)',
@@ -16,6 +17,7 @@ export const tomato: Color = {
     12: 'hsl(10, 50.0%, 13.5%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(10, 23.0%, 9.4%)',
     2: 'hsl(9, 44.8%, 11.4%)',
     3: 'hsl(8, 52.0%, 15.3%)',

--- a/libs/platform/experience/src/color/colors/colored/violet.ts
+++ b/libs/platform/experience/src/color/colors/colored/violet.ts
@@ -2,6 +2,7 @@ import { Color } from '../../color.model';
 
 export const violet: Color = {
   light: {
+    0: 'white',
     1: 'hsl(255, 65.0%, 99.4%)',
     2: 'hsl(252, 100%, 99.0%)',
     3: 'hsl(252, 96.9%, 97.4%)',
@@ -16,6 +17,7 @@ export const violet: Color = {
     12: 'hsl(254, 60.0%, 18.5%)',
   },
   dark: {
+    0: 'white',
     1: 'hsl(250, 20.0%, 10.2%)',
     2: 'hsl(255, 30.3%, 12.9%)',
     3: 'hsl(253, 37.0%, 18.4%)',


### PR DESCRIPTION
Added `white` for all non-bright radix colors on the zero position. 

closes: #1092