### PR TITLE
Fix IndexedDB interface typo

### DIFF
--- a/libs/platform/indexed-db/src/models/db-instance.model.ts
+++ b/libs/platform/indexed-db/src/models/db-instance.model.ts
@@ -4,18 +4,23 @@ declare global {
   /**
    * Specify the type of IndexedDB instance by providing `type` property with it's type.
    *
-   * The provided type is available in an alias {@link IndexedDbIntanceType}.
+ * The provided type is available in an alias {@link IndexedDbInstanceType}.
    *
    * @example
    * ```ts
    * declare global {
-   *   interface IndexedDbIntance {
+ *   interface IndexedDbInstance {
    *     type: MyDbTypeHere;
    *   }
    * ```
    */
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface IndexedDbIntance {}
+  interface IndexedDbInstance {}
+  /**
+   * @deprecated Use {@link IndexedDbInstance} instead.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface IndexedDbIntance extends IndexedDbInstance {}
 
   /**
    * Specify the type of migration function arguments by providing `args` property with it's type.
@@ -71,9 +76,12 @@ declare global {
   interface IndexedDbEntityMap {}
 }
 
-export type IndexedDbIntanceType = IndexedDbIntance extends { type: infer T }
+export type IndexedDbInstanceType = IndexedDbInstance extends { type: infer T }
   ? T
   : unknown;
+
+/** @deprecated Use {@link IndexedDbInstanceType} instead. */
+export type IndexedDbIntanceType = IndexedDbInstanceType;
 
 export type IndexedDbMigrationArgsType = IndexedDbMigrationArgs extends {
   args: [...infer T];

--- a/libs/platform/indexed-db/src/models/versioned.model.ts
+++ b/libs/platform/indexed-db/src/models/versioned.model.ts
@@ -1,5 +1,5 @@
 import {
-  IndexedDbIntanceType,
+  IndexedDbInstanceType,
   IndexedDbMigrationArgsType,
 } from './db-instance.model';
 
@@ -10,6 +10,6 @@ export interface IndexedDbVersioned {
 }
 
 export type IndexedDbMigrationFn = (
-  db: IndexedDbIntanceType,
+  db: IndexedDbInstanceType,
   ...args: IndexedDbMigrationArgsType
 ) => void | Promise<void>;

--- a/libs/platform/indexed-db/src/services/dexie-indexed-db.service.ts
+++ b/libs/platform/indexed-db/src/services/dexie-indexed-db.service.ts
@@ -21,9 +21,13 @@ import { DexieIndexedDbConfig } from './dexie-config.provider';
 import { IndexedDbService } from './indexed-db.service';
 
 declare global {
-  interface IndexedDbIntance {
+  interface IndexedDbInstance {
     type: OryxDexieDb;
   }
+  /**
+   * @deprecated Use {@link IndexedDbInstance} instead.
+   */
+  interface IndexedDbIntance extends IndexedDbInstance {}
 
   interface IndexedDbMigrationArgs {
     args: [Transaction];
@@ -156,7 +160,7 @@ export class DexieIndexedDbService implements IndexedDbService<OryxDexieDb> {
       const migrations = this.getMigrations(metadataGroup.metadata);
 
       this.debug(
-        `Settinp up IndexedDb version ${metadataGroup.version} with schema`,
+        `Setting up IndexedDb version ${metadataGroup.version} with schema`,
         schema
       );
 

--- a/libs/platform/indexed-db/src/services/indexed-db.service.ts
+++ b/libs/platform/indexed-db/src/services/indexed-db.service.ts
@@ -1,11 +1,11 @@
 import { Observable } from 'rxjs';
 import {
   IndexedDbEntityType,
-  IndexedDbIntanceType,
+  IndexedDbInstanceType,
   InferIndexedDbStore,
 } from '../models';
 
-export interface IndexedDbService<TdbInstance = IndexedDbIntanceType> {
+export interface IndexedDbService<TdbInstance = IndexedDbInstanceType> {
   registerEntities(entityTypes: IndexedDbEntityType[]): Observable<void>;
   getDb(): Observable<TdbInstance>;
   getStoreName(entityType: IndexedDbEntityType): string;


### PR DESCRIPTION
## Summary
- fix typos in IndexedDB instance typings and keep backwards compatibility
- correct debug log message wording

## Testing
- `npm test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515dd9c0d8832689ac79abba4bd290